### PR TITLE
override EventTarget.prototype methods

### DIFF
--- a/index.html
+++ b/index.html
@@ -297,16 +297,31 @@
     }
     investigate(document, 1);
 
-    const originalAddEventListener = window.addEventListener;
-    const originalRemoveEventListener = window.removeEventListener;
-    window.addEventListener = function(...args) {
-        const str = `window.addEventListener('${args[0]}', ${args.slice(1).map((arg) => renderParam(arg)).join(", ")}`
-        appendEvent(str, 1)
-        return originalAddEventListener.apply(window, args)
+    const originalAddEventListener = EventTarget.prototype.addEventListener;
+    const originalRemoveEventListener = EventTarget.prototype.removeEventListener;
+
+    function getTargetName (target) {
+        switch (target) {
+            case window: return "window";
+            case document: return "document";
+            default: return;
+        }
     }
-    window.removeEventListener = function() {
-        appendEvent("window.removeEventListener('" + arguments[0] + "')", 1)
-        return originalRemoveEventListener.apply(window, arguments)
+
+    EventTarget.prototype.addEventListener = function(...args) {
+        const targetName = getTargetName(this);
+        if (targetName) {
+            const str = `${targetName}.addEventListener('${args[0]}', ${args.slice(1).map((arg) => renderParam(arg)).join(", ")}`
+            appendEvent(str, 1)
+        }
+        return originalAddEventListener.apply(this, args)
+    }
+    EventTarget.prototype.removeEventListener = function() {
+        const targetName = getTargetName(this);
+        if (targetName){
+            appendEvent(`${targetName}.removeEventListener('${arguments[0]}')`, 1)
+        }
+        return originalRemoveEventListener.apply(this, arguments)
     }
 </script>
 


### PR DESCRIPTION
First off, love the project – it is very much needed! I didn't see a way to open an issue nor contribution guidelines, I'm sure you're busy at the moment so feel free to disregard, reply to this whenever, or let me know if there's a better way than an unsolicited PR from someone on the Internet.

Anyway I noticed a malicious site can circumvent the override on `window.addEventListener` by doing `EventTarget.prototype.addEventListener.call(window, eventName, handler)`. In this patch, instead the underlying prototype methods are overridden. To test, the following code will trip the _potentially dangerous_ warning on this branch but not on master.
```
EventTarget.prototype.addEventListener.call(window, "keypress", (e) => { /* something fishy */ })
```

I'm only logging handlers on `document` and `window` but it adding `document.body` might be a good idea.